### PR TITLE
rtl8723ds_bt: use correct firmware configuration filename for CHIP PR…

### DIFF
--- a/gadget/package/rtl8723ds_bt/Config.in
+++ b/gadget/package/rtl8723ds_bt/Config.in
@@ -24,6 +24,6 @@ default /dev/ttyS2
 config BR2_PACAKGE_RTL8723DS_BT_CONFIG
 prompt "Firmware Configuration File"
 string
-default rtl8723d_fw
+default rtl8723d_config
 
 endif


### PR DESCRIPTION
…O as package default